### PR TITLE
Bump version for previous commit.

### DIFF
--- a/lib/cmsify_assets/version.rb
+++ b/lib/cmsify_assets/version.rb
@@ -1,3 +1,3 @@
 module CmsifyAssets
-  VERSION = "0.0.1"
+  VERSION = "0.0.2"
 end


### PR DESCRIPTION
@joshreeves in order for bundler to recognize chagnes, the version must always be bumped. All PRs should have a bump for cmsify-assets. 