### PR TITLE
new featured item flow

### DIFF
--- a/lib/cmsify_assets/version.rb
+++ b/lib/cmsify_assets/version.rb
@@ -1,3 +1,3 @@
 module CmsifyAssets
-  VERSION = "0.0.14"
+  VERSION = "0.0.15"
 end

--- a/vendor/assets/javascripts/initializers.js
+++ b/vendor/assets/javascripts/initializers.js
@@ -65,6 +65,7 @@ $(document).on('turbolinks:load', function() {
         $('.js-featured-image').attr('src', res.attachment.url).removeClass('uk-hidden');
         $(clone).find('img').first().attr('src', res.attachment.icon.url);
         $(clone).first().removeClass('uk-hidden');
+        UIkit.modal('#add-new-featured-image').hide();
       });
   });
   $('.js-featured-image-table-element').each(function() {

--- a/vendor/assets/javascripts/remote_upload.js
+++ b/vendor/assets/javascripts/remote_upload.js
@@ -1,4 +1,4 @@
-Cmsify.remoteUpload = function(form, elementToClone, elementToInsertBefore, callback) {
+var remoteUpload = Cmsify.remoteUpload = function(form, elementToClone, elementToInsertBefore, callback) {
   form.dropzone({
     dictDefaultMessage: 'Drop files or click here to upload',
     init: function() {
@@ -18,7 +18,9 @@ Cmsify.remoteUpload = function(form, elementToClone, elementToInsertBefore, call
         }
         $clone.insertBefore($(elementToInsertBefore).first());
         if (typeof callback === 'function') callback(elementToClone, $input, req, res);
-      });
+        this.destroy();
+        remoteUpload(form, elementToClone, elementToInsertBefore, callback);
+      }.bind(this));
     }
   })
 };


### PR DESCRIPTION
@joshreeves @shenst1 I just went with a destroy/new creation for the dropzone reset, doesn't seem to be a better solution as per this thread: https://github.com/enyo/dropzone/issues/44 since I'm recursively calling the remoteUpload function there is the potential for a memory leak but since this is rails and it's unlikely that the user will upload multiple thousand images in the collection view before changing views, so I think it should be fine.