### PR TITLE
remove image button using a hidden field

### DIFF
--- a/lib/cmsify_assets/version.rb
+++ b/lib/cmsify_assets/version.rb
@@ -1,3 +1,3 @@
 module CmsifyAssets
-  VERSION = "0.0.15"
+  VERSION = "0.0.16"
 end

--- a/vendor/assets/javascripts/initializers.js
+++ b/vendor/assets/javascripts/initializers.js
@@ -77,10 +77,11 @@ $(document).on('turbolinks:load', function() {
     });
   });
   $('.js-remove-image').each(function() {
-    $(this).find('a').on('click', function(event) {
-      $(this).find('input').first().val(1);
-      $('.' + this.dataset.target).addClass('uk-hidden');
-      $(this).addClass('uk-hidden');
+    var $this = $(this);
+    $this.on('click', function() {
+      $this.find("input[name*='_destroy']").first().val(1);
+      $($this.data('target')).addClass('uk-hidden');
+      $this.addClass('uk-hidden');
     }.bind(this));
   });
 });

--- a/vendor/assets/javascripts/initializers.js
+++ b/vendor/assets/javascripts/initializers.js
@@ -66,12 +66,21 @@ $(document).on('turbolinks:load', function() {
         $(clone).find('img').first().attr('src', res.attachment.icon.url);
         $(clone).first().removeClass('uk-hidden');
         UIkit.modal('#add-new-featured-image').hide();
+        $('.js-remove-image').removeClass('uk-hidden');
       });
   });
   $('.js-featured-image-table-element').each(function() {
     var imageUrl = $(this).data('imageUrl');
     $(this).find('input').on('click', function(event) {
       $('.js-featured-image').attr('src', imageUrl).removeClass('uk-hidden');
+      $('.js-remove-image').removeClass('uk-hidden');
     });
+  });
+  $('.js-remove-image').each(function() {
+    $(this).find('a').on('click', function(event) {
+      $(this).find('input').first().val(1);
+      $('.' + this.dataset.target).addClass('uk-hidden');
+      $(this).addClass('uk-hidden');
+    }.bind(this));
   });
 });


### PR DESCRIPTION
@joshreeves @shenst1 use a :_destroy hidden field to remove an image and it's preview, used `data-target` for the image class so this can be more easily reused. Also makes sure to display the trashcan button when a featured image gets added again after a removal.