### PR TITLE
only make an ajax if a sort-action is specified

### DIFF
--- a/lib/cmsify_assets/version.rb
+++ b/lib/cmsify_assets/version.rb
@@ -1,3 +1,3 @@
 module CmsifyAssets
-  VERSION = "0.0.19"
+  VERSION = "0.0.20"
 end

--- a/vendor/assets/javascripts/sortables.js
+++ b/vendor/assets/javascripts/sortables.js
@@ -6,11 +6,13 @@ Cmsify.Sortable = function(el, options) {
     this.$el.find('.js-rank').each(function(i) {
       $(this).attr('value', i + 1);
     });
-    $.ajax({
-      type: 'PUT',
-      url: this.$el.data('sort-action'),
-      data: { order: this.$el.find('.js-rank').serializeArray() },
-    });
+    if (this.$el.data('sort-action')) {
+      $.ajax({
+        type: 'PUT',
+        url: this.$el.data('sort-action'),
+        data: { order: this.$el.find('.js-rank').serializeArray() },
+      });
+    }
   }.bind(this));
 };
 


### PR DESCRIPTION
@joshreeves @shenst1 only submit an ajax request for sorting if a `sort-action` is specified. Used in https://github.com/plyinteractive/spr-admin/pull/169