### PR TITLE
Punchlist items.

### DIFF
--- a/lib/cmsify_assets/version.rb
+++ b/lib/cmsify_assets/version.rb
@@ -1,3 +1,3 @@
 module CmsifyAssets
-  VERSION = "0.0.22"
+  VERSION = "0.0.23"
 end

--- a/vendor/assets/stylesheets/components/abbr.scss
+++ b/vendor/assets/stylesheets/components/abbr.scss
@@ -1,0 +1,4 @@
+abbr[title] {
+  border-bottom: none;
+  color: $c-persian-red;
+}

--- a/vendor/assets/stylesheets/components/utility.scss
+++ b/vendor/assets/stylesheets/components/utility.scss
@@ -4,3 +4,7 @@
     text-decoration: none !important;
   }
 }
+
+.cmsify-width-medium {
+  width: 350px;
+}


### PR DESCRIPTION
@joshreeves needed to make the 350 class to restrict width of images uploaded so they aren't huge. Fixed width is really the only way to go because the layout ends up in both the ```aside``` and ```article``` columns. The fixed width classes don't exist in UIKit2 