### PR TITLE
Dry up asset uploads so we get some stuff for freeeeee

### DIFF
--- a/lib/cmsify_assets/version.rb
+++ b/lib/cmsify_assets/version.rb
@@ -1,3 +1,3 @@
 module CmsifyAssets
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end

--- a/vendor/assets/javascripts/behaviors/remote_upload.js
+++ b/vendor/assets/javascripts/behaviors/remote_upload.js
@@ -5,19 +5,25 @@ var remoteUpload = Cmsify.remoteUpload = function(form, elementToClone, elementT
       this.on('success', function(req, res) {
         var $clone = $(elementToClone).clone().first();
         var $input = $clone.is('input') ? $clone : $clone.find('input').first();
-        //if the element is of type input, change the input to match the new id from the server
+        var $img = $clone.find('img');
         if ($input) {
           var baseId = $input.attr('id').split('_');
           baseId.pop();
-          baseId.push(res.id);
+          baseId.push(res.asset.id);
           $input.attr({
             'id': baseId.join('_'),
             'checked': true
           });
-          $input.val(res.id);
+          $input.val(res.asset.id);
         }
+        if ($img) {
+          $img.attr('src', res.asset.url);
+        }
+        $clone.data('asset-url', res.asset.url);
+        $clone.data('asset-type', res.asset.type);
         $clone.removeClass('uk-hidden');
         $clone.insertBefore($(elementToInsertBefore).first());
+        new Cmsify.SelectableAsset($clone).select();
         if (typeof callback === 'function') callback(elementToClone, $input, req, res);
         this.destroy();
         remoteUpload(form, elementToClone, elementToInsertBefore, callback);

--- a/vendor/assets/javascripts/behaviors/selectable_asset.js
+++ b/vendor/assets/javascripts/behaviors/selectable_asset.js
@@ -1,0 +1,17 @@
+Cmsify.SelectableAsset = function(el) {
+  this.$el = $(el);
+  this.select = this.select.bind(this);
+  this.$el.on('click', this.select);
+  return this;
+};
+
+Cmsify.SelectableAsset.prototype.select = function() {
+  $('.js-' + this.$el.data('asset-name')).html(this.renderImageOrFileName());
+  $('.js-remove-asset').removeClass('uk-hidden');
+};
+
+Cmsify.SelectableAsset.prototype.renderImageOrFileName = function() {
+  return this.$el.data('asset-type').includes('image') ?
+    $('<img class="cmsify-width-medium " src="' + this.$el.data('asset-url') + '" />') :
+    this.$el.data('asset-url').split('/').pop();
+};

--- a/vendor/assets/javascripts/behaviors/selectable_rows.js
+++ b/vendor/assets/javascripts/behaviors/selectable_rows.js
@@ -2,13 +2,8 @@ Cmsify.SelectableRows = function(el) {
   this.$el = $(el);
   this.$el.find('tr').each(function() {
     var $this = $(this);
-    var $inputs = $this.find(':radio, :checkbox');
     $this.on('click', function(e) {
-      e.preventDefault();
-      $inputs.trigger('click');
-    });
-    $inputs.on('click', function(e) {
-      e.stopPropagation();
+      $this.find(':radio, :checkbox').prop('checked', true);
     });
   });
 };

--- a/vendor/assets/javascripts/initializers/asset_uploads.js
+++ b/vendor/assets/javascripts/initializers/asset_uploads.js
@@ -13,64 +13,21 @@ $(document).on('cmsify:load', function() {
       }
     });
   });
-  $('.js-dropzone-image-upload').each(function() {
+  $('.js-dropzone-asset-upload').each(function() {
     var resourceName = this.dataset.resourceName;
     Cmsify.remoteUpload($(this).find('form'),
       '.js-' + resourceName + '-table-element',
       '.js-' + resourceName + '-table-element',
       function(clone, cloneInput, req, res) {
-        $('.js-' + resourceName).attr('src', res.attachment.url).removeClass('uk-hidden');
-        $(clone).find('img').first().attr('src', res.attachment.icon.url);
         $(clone).first().removeClass('uk-hidden');
         UIkit.modal('#add-new-' + resourceName).hide();
-        $('.js-remove-image').removeClass('uk-hidden');
+        $('.js-remove-asset').removeClass('uk-hidden');
       });
   });
-  $('.js-dropzone-asset-upload').each(function() {
-    Cmsify.remoteUpload($(this).find('form'),
-      '.js-asset-table-element',
-      '.js-asset-table-element',
-      function(clone, cloneInput, req, res) {
-        UIkit.modal('#add-new-asset').hide();
-        var urlArray = res.attachment.url.split('/');
-        var $jsAsset = $('.js-asset').first();
-        var $anchor = $jsAsset.find('a').first();
-        $anchor.text(urlArray[urlArray.length - 1]);
-        $anchor.attr('href', "/admin/assets/" + res.id);
-        $jsAsset.removeClass('uk-hidden');
-        $('.js-asset-hide-on-select').addClass('uk-hidden');
-      }
-    );
+  $('.js-selectable').each(function() {
+    new Cmsify.SelectableAsset(this);
   });
-  $('.js-asset-table-element').each(function() {
-    var $this = $(this);
-    var $tableImg = $this.find('img');
-    var $jsAsset = $('.js-asset').first();
-    var $toBeHidden = $('.js-asset-hide-on-select');
-    $this.find('input').on('click', function() {
-      var $anchor = $jsAsset.find('a').first();
-      var $assetImg = $jsAsset.find('img').first();
-      $anchor.text($this.find('a').text());
-      $anchor.attr('href', $this.find('a').first().attr('href'));
-      if ($tableImg.length) {
-        $assetImg.attr('src', $tableImg.first().attr('src'));
-        $assetImg.removeClass('uk-hidden');
-      } else {
-        $assetImg.addClass('uk-hidden');
-      }
-      $jsAsset.removeClass('uk-hidden');
-      $toBeHidden.addClass('uk-hidden');
-    });
-  });
-  $('.js-image-element').each(function() {
-    var $this = $(this);
-    var imageUrl = $this.data('imageUrl');
-    $this.find('input').on('click', function(event) {
-      $($this.data('imageTarget')).attr('src', imageUrl).removeClass('uk-hidden');
-      $('.js-remove-image').removeClass('uk-hidden');
-    });
-  });
-  $('.js-remove-image').each(function() {
+  $('.js-remove-asset').each(function() {
     var $this = $(this);
     $this.on('click', function() {
       $this.find("input[name*='_destroy']").first().val(1);


### PR DESCRIPTION
@toastynerd @shenst1 

- Added `Cmsify.SelectableAsset` class to encapsulate all functionality related to selecting and rendering a selected asset. Currently it displays either an `img` or the attachment file name, depending on `data-asset-type`.
- Uploading an asset now initializes a new clones an element with all the necessary info and creates an instance of `Cmsify.SelectableAsset` and then selects that instance. So uploading and selecting now work identically.
- Some other misc cleanup