### PR TITLE
limit asset_uploads to a single file

### DIFF
--- a/vendor/assets/javascripts/behaviors/remote_upload.js
+++ b/vendor/assets/javascripts/behaviors/remote_upload.js
@@ -1,6 +1,11 @@
 var remoteUpload = Cmsify.remoteUpload = function(form, elementToClone, elementToInsertBefore, callback) {
   form.dropzone({
     dictDefaultMessage: 'Drop files or click here to upload',
+    maxFiles: 1,
+    maxfilesexceeded: function(file) {
+      this.removeAllFiles();
+      this.addFile(file); 
+    },
     init: function() {
       this.on('success', function(req, res) {
         var $clone = $(elementToClone).clone().first();


### PR DESCRIPTION
@joshreeves @shenst1 limit the max number of files to 1 for asset uploads and if a user drags multiple files display only the last one.